### PR TITLE
Fix V1 reader making short class name mappings

### DIFF
--- a/src/main/java/net/fabricmc/mapping/tree/TinyMappingFactory.java
+++ b/src/main/java/net/fabricmc/mapping/tree/TinyMappingFactory.java
@@ -165,7 +165,9 @@ public final class TinyMappingFactory {
 			String className = splitLine[1];
 			ClassImpl parent = firstNamespaceClassEntries.get(className);
 			if (parent == null) {
-				parent = new ClassImpl(namespaceMapper, new String[]{className}); // No class for my field, sad!
+				String[] name = new String[namespaceList.length];
+				Arrays.fill(name, className);
+				parent = new ClassImpl(namespaceMapper, name); // No class for my field, sad!
 				firstNamespaceClassEntries.put(className, parent);
 				classEntries.add(parent);
 			}
@@ -179,7 +181,9 @@ public final class TinyMappingFactory {
 			String className = splitLine[1];
 			ClassImpl parent = firstNamespaceClassEntries.get(className);
 			if (parent == null) {
-				parent = new ClassImpl(namespaceMapper, new String[] {className}); // No class for my field, sad!
+				String[] name = new String[namespaceList.length];
+				Arrays.fill(name, className);
+				parent = new ClassImpl(namespaceMapper, name); // No class for my field, sad!
 				firstNamespaceClassEntries.put(className, parent);
 				classEntries.add(parent);
 			}


### PR DESCRIPTION
Direct readers would not count the classes which had implicit mappings at all (just supplying the members immediately), but when you're making a tree there's no way around the situation when the members have to be attached to something. This is more or less the equivalent such that it noops the mapping without it appearing as completely absent. Also fixes it crashing `ClassDef#getRawName` which doesn't bounds check for when the array is short.