### PR TITLE
De-duplicate strings when loading mappings

### DIFF
--- a/src/main/java/net/fabricmc/mapping/util/StringPool.java
+++ b/src/main/java/net/fabricmc/mapping/util/StringPool.java
@@ -1,0 +1,39 @@
+package net.fabricmc.mapping.util;
+
+import java.util.HashMap;
+
+/**
+ * A pool of strings used for de-duplication.
+ */
+public class StringPool {
+    // The HashMap uses value-equality to de-duplicate keys. Because we need a value type, we simply stuff the key
+    // reference back in to make the code below pretty.
+    private final HashMap<String, String> map = new HashMap<>();
+
+    /**
+     * Adds a string to the pool, returning a de-duplicated reference to the string.
+     * @param str The string to de-duplicate
+     * @return A de-duplicated reference to a string with the same contents as {@param str}
+     */
+    public String pool(String str) {
+        return this.map.computeIfAbsent(str, StringPool::identity);
+    }
+
+    /**
+     * @param strings The array of strings to de-duplicate
+     * @return A new array of de-duplicated strings (see {@link StringPool#pool(String)})
+     */
+    public String[] pool(String[] strings) {
+        String[] dedupStrings = new String[strings.length];
+
+        for (int i = 0; i < strings.length; i++) {
+            dedupStrings[i] = this.pool(strings[i]);
+        }
+
+        return dedupStrings;
+    }
+
+    private static <T> T identity(T obj) {
+        return obj;
+    }
+}

--- a/src/main/java/net/fabricmc/mapping/util/StringPool.java
+++ b/src/main/java/net/fabricmc/mapping/util/StringPool.java
@@ -1,9 +1,26 @@
+/*
+ * Copyright 2021 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.mapping.util;
 
 import java.util.HashMap;
+import java.util.function.Function;
 
 /**
- * A pool of strings used for de-duplication.
+ * A pool of strings used for de-duplicating string references.
  */
 public class StringPool {
     // The HashMap uses value-equality to de-duplicate keys. Because we need a value type, we simply stuff the key
@@ -16,24 +33,19 @@ public class StringPool {
      * @return A de-duplicated reference to a string with the same contents as {@param str}
      */
     public String pool(String str) {
-        return this.map.computeIfAbsent(str, StringPool::identity);
+        return this.map.computeIfAbsent(str, Function.identity() /* computed value is the key */);
     }
 
     /**
+     * De-duplicates an array of strings in-place.
      * @param strings The array of strings to de-duplicate
-     * @return A new array of de-duplicated strings (see {@link StringPool#pool(String)})
+     * @return The value passed to the {@param strings}
      */
     public String[] pool(String[] strings) {
-        String[] dedupStrings = new String[strings.length];
-
         for (int i = 0; i < strings.length; i++) {
-            dedupStrings[i] = this.pool(strings[i]);
+            strings[i] = this.pool(strings[i]);
         }
 
-        return dedupStrings;
-    }
-
-    private static <T> T identity(T obj) {
-        return obj;
+        return strings;
     }
 }


### PR DESCRIPTION
This is a small patch which adds a `StringPool` to de-duplicate strings as a mapping file is parsed. The amount of overhead added by this is almost immeasurable against the rest of the parsing functions, and while we're only saving peanuts here, it seems worthwhile enough to me at least.

With the latest Yarn mappings for Minecraft 1.16.5, this reduces the amount of heap used by strings in the loaded mappings from ~6.7 MB to ~1.3 MB in-game.